### PR TITLE
Remove department path variable

### DIFF
--- a/src/main/java/amu/zhcet/core/admin/attendance/AttendanceDownloadController.java
+++ b/src/main/java/amu/zhcet/core/admin/attendance/AttendanceDownloadController.java
@@ -81,9 +81,8 @@ public class AttendanceDownloadController {
      * @param course Course for which the attendance is to be downloaded
      * @param response Response object to be sent, containing the attendance CSV
      */
-    @GetMapping("/admin/department/{department}/floated/{course}/attendance.csv")
-    public ResponseEntity<InputStreamResource> downloadAttendanceForDepartment(@PathVariable Department department, @PathVariable Course course, HttpServletResponse response) {
-        ErrorUtils.requireNonNullDepartment(department);
+    @GetMapping("/admin/department/floated/{course}/attendance.csv")
+    public ResponseEntity<InputStreamResource> downloadAttendanceForDepartment(@PathVariable Course course, HttpServletResponse response) {
         ErrorUtils.requireNonNullCourse(course);
         return downloadAttendance("department", course);
     }


### PR DESCRIPTION
fixes #131 
The download URL in the department panel expects a `department` object as parameter. But this object was not present in case of admin. Hence the URL reduced to: `/admin/department/floated/{course}/attendance.csv`. Which returned 404.
Also the department object was not being used at all in the fetch attendance process. So I removed it.
Please let me know if there can be a better solution for this. 
