### PR TITLE
fix: Trim the username on auth failure

### DIFF
--- a/src/main/java/amu/zhcet/auth/login/handler/UsernameAuthenticationFailureHandler.java
+++ b/src/main/java/amu/zhcet/auth/login/handler/UsernameAuthenticationFailureHandler.java
@@ -23,7 +23,10 @@ public class UsernameAuthenticationFailureHandler extends SimpleUrlAuthenticatio
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-        request.getSession().setAttribute(USERNAME, request.getParameter(USERNAME));
+        String username = request.getParameter(USERNAME);
+        if (username != null) {
+            request.getSession().setAttribute(USERNAME, username.trim());
+        }
         super.onAuthenticationFailure(request, response, exception);
     }
 }


### PR DESCRIPTION
The username received from Spring was trimmed of whitespaces
and the manual username for generating error was not, resulting
in key mismatch and thus wrong value being fetched from cache

Fixes #143 